### PR TITLE
Add develop mode to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -55,4 +55,4 @@ deps = -r{toxinidir}/requirements.txt
        ipython
 usedevelop=true
 allowlist_externals = echo
-commands = echo "Done!"
+commands = echo "Done! Usage: source .tox/develop/bin/activate"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py27,py3{6,8,10,12},pep8
 
+
 [testenv]
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
@@ -9,13 +10,16 @@ setenv =
 commands =
   coverage run -p -m pytest {posargs} --timer-top-n=10 {env:TEST_PATH}
 
+
 [tox:jenkins]
 sitepackages = True
 downloadcache = ~/cache/pip
 
+
 [testenv:pep8]
 commands =
   flake8
+
 
 [testenv:cover]
 deps = -r{toxinidir}/requirements.txt
@@ -26,13 +30,16 @@ commands =
   coverage report --omit=.tox/*,yretry/tests/*,memory:0x*
   coverage html -d cover --omit=.tox/*,yretry/tests/*,memory:0x*
 
+
 [testenv:venv]
 commands = {posargs}
+
 
 [flake8]
 show-source = true
 builtins = _
 exclude = .git,.tox,dist,doc,*lib/python*,*egg,build*
+
 
 [testenv:doc]
 deps = -r{toxinidir}/requirements.txt
@@ -40,3 +47,12 @@ deps = -r{toxinidir}/requirements.txt
 commands =
   python {toxinidir}/tools/validate-json-schemas.py -G {toxinidir}/doc/source/api/v1/schemas/*
   python setup.py build_sphinx
+
+
+[testenv:develop]
+deps = -r{toxinidir}/requirements.txt
+       -r{toxinidir}/test-requirements.txt
+       ipython
+usedevelop=true
+allowlist_externals = echo
+commands = echo "Done!"


### PR DESCRIPTION
To enable developer environment, use:
```
tox -e develop
source .tox/develop/bin/activate
```

to deactivate development environment:
```
deactivate
```

to rebuild environment, use:
```
tox -e develop -r
```